### PR TITLE
fix exit status

### DIFF
--- a/examples/pds_verify
+++ b/examples/pds_verify
@@ -38,7 +38,7 @@ warn "$range set(s) not normalized\n"        if $range;
 warn "$not set(s) proven to be wrong\n"      if $not;
 warn "$proven set(s) proven to be correct\n" if $proven;
 
-exit $syntax + $range + $not? 1: 0;
+exit($syntax + $range + $not ? 1 : 0);
 
 __END__
 


### PR DESCRIPTION
`exit` has higher precedence than `?:`, so `exit $syntax + $range + $not ? 1 : 0` parses as `(exit $syntax + $range + $not) ? 1 : 0`, which is not what was intended.